### PR TITLE
Decode is not passed as an attribute to img anymore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ class Img extends Component {
     // if we have loaded, show img
     if (this.state.isLoaded) {
       // clear non img props
-      let {src, loader, unloader, ...rest} = this.props //eslint-disable-line
+      let {src, loader, unloader, decode, ...rest} = this.props //eslint-disable-line
       return <img src={this.sourceList[this.state.currentIndex]} {...rest} />
     }
 


### PR DESCRIPTION
React@16 complains about decode attribute:
"Warning: Received true for non-boolean attribute decode. If this is expected, cast the value to a string."

It happens because the boolean prop is passed to the img tag, but as far as I can understand it's not required to pass it.