### PR TITLE
Fix TypeError: Derived constructors may only return object or undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class Img extends Component {
       /* istanbul ignore else */
       if (cache[this.sourceList[i]] === true) {
         this.state = {currentIndex: i, isLoading: false, isLoaded: true}
-        return true
+        return
       }
     }
 


### PR DESCRIPTION
A class constructor can either return or return an object. If we return true here to exit it will error with `TypeError: Derived constructors may only return object or undefined` during HMR.

Removing true, and just return will fix this problem.