### PR TITLE
Correct the sample polyfill code

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ see above
 3. Include the following code before including `react-image`:
 
 ```js
-Object.assign ||
+Object.assign = Object.assign ||
   function(r) {
     for (var t = 1; t < arguments.length; t++) {
       var n = arguments[t]


### PR DESCRIPTION
Previous version did not save the result of the execution of the polyfill.

Although I would prefer against including this suggestion in the readme anyway. For people who are not comfortable customizing their target platform it’s better to use a safe Mozilla’s polyfill anyway.