### PR TITLE
Adds a `crossorigin` prop to `Img`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ const myComponent = () => (
 )
 ```
 
+### Loading images with a CORS policy
+
+When loading images from another domain with a [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes), you may find you need to use the `crossorigin` attribute. For example:
+
+```js
+const myComponent = () => (
+  <Img src={'https://www.example.com/foo.jpg'} crossorigin="anonymous" />
+)
+```
+
 ### Animations and other advanced uses
 
 A wrapper element `container` can be used to facilitate higher level operations which are beyond the scope of this project. `container` takes a single property, `children` which is whatever is passed in by **React Image** (i.e. the final `<img>` or the loaders).

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const imgPropTypes = {
   loader: node,
   unloader: node,
   decode: bool,
+  crossorigin: string,
   src: oneOfType([string, array]),
   container: func,
   loaderContainer: func,
@@ -131,6 +132,10 @@ class Img extends Component {
     }
     this.i.src = this.sourceList[this.state.currentIndex]
 
+    if (this.props.crossorigin) {
+      this.i.crossorigin = this.props.crossorigin;
+    }
+
     if (this.props.decode && this.i.decode) {
       this.i
         .decode()
@@ -203,6 +208,7 @@ class Img extends Component {
 
       // props to exclude from the rest property
       src,
+      crossorigin,
       decode,
       loaderContainer,
       unloaderContainer,


### PR DESCRIPTION
Fixes mbrevda/react-image#227 by adding a `crossorigin` prop to the `Img` component, allowing loading of images with a CORS policy.