### PR TITLE
Fix reset of onerror and onload handler on image unloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.1.3
+===
+* fix: nullify callbacks before removing - #237
+
 2.1.2
 ===
 * fix: don't call handlers multiple times, fixes: #236

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "React Image is an <img> tag replacement for react, featuring preloader and multiple image fallback support",
   "scripts": {
     "build": "NODE_ENV=production rollup -c && node ./webpack.site.js && for i in cjs esm umd; do cp src/*test.js $i; done",

--- a/src/index.js
+++ b/src/index.js
@@ -148,8 +148,8 @@ class Img extends Component {
   }
 
   unloadImg = () => {
-    delete this.i.onerror
-    delete this.i.onload
+    this.i.onerror = null
+    this.i.onload = null
 
     // abort any current downloads https://github.com/mbrevda/react-image/pull/223
     this.i.src = ''

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -123,8 +123,9 @@ test('onError does nothing if unmounted', () => {
   const inst = i.instance()
   inst.componentDidMount()
   const img = inst.i
+  expect(img.onerror).not.toBe(null)
   i.unmount()
-  expect(img.onerror()).toBe(false)
+  expect(img.onerror).toBe(null)
 })
 
 test('onError if there are no more sources, we are done', () => {


### PR DESCRIPTION
* delete does not reset the callback attached to this.i.onerror/onload
* instead, reset to null (default)
* increment version to 2.1.3

Thx @albertodiazdorado for debugging this