### PR TITLE
Customized onError property function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ class Img extends Component {
       this.i
         .decode()
         .then(this.onLoad)
-        .catch(this.onError)
+        .catch(this.props.onError || this.onError)
     } else {
       this.i.onload = this.onLoad
       this.i.onerror = this.onError


### PR DESCRIPTION
Sometimes when the component could not get the image data from a URL, instead of displaying nothing, we want some customized actions. So, if onError function is passed down to Img component, it will get executed. Otherwise, it remains the current behavior.