### PR TITLE
change the depricated lifecycle method's name to prevent react's warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.2.1
+===
+* fix: Removes warnings of unsafe lifecycle methods from console due to react 16.9 update.
+
 2.2.0
 ===
 * fix:Use correct case for crossOrigin and ensure prop is used both for the initial image fetch and in the final `<img>` element

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "React Image is an <img> tag replacement for react, featuring preloader and multiple image fallback support",
   "scripts": {
     "build": "NODE_ENV=production rollup -c && node ./webpack.site.js && for i in cjs esm umd; do cp src/*test.js $i; done",

--- a/src/index.js
+++ b/src/index.js
@@ -176,7 +176,7 @@ class Img extends Component {
     if (this.i) this.unloadImg()
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.loaderContainer = nextProps.loaderContainer || nextProps.container
     this.unloaderContainer = nextProps.unloaderContainer || nextProps.container
 


### PR DESCRIPTION
Since react 16.9 update console has started to show deprecated life cycle methods warning for the methods that are deprecated after v16.3, warnings can be removed if you add an UNSAFE prefix before your method see this[https://reactjs.org/blog/2019/08/08/react-v16.9.0.html](url). In this PR i've just added a prefix of UNSAFE to prevent the warnings.