### PR TITLE
Commit fixes Issue #260

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.4.0
+- fix: TS Interface Error for 'src' attribute. Related to issue: #260
+
 # 2.3.0
 
 - fix: typescript declarations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "React Image is an <img> tag replacement for react, featuring preloader and multiple image fallback support",
   "scripts": {
     "build": "NODE_ENV=production rollup -c && for i in cjs esm umd; do cp src/*test.js $i; done",

--- a/react-image.d.ts
+++ b/react-image.d.ts
@@ -1,7 +1,7 @@
 declare module 'react-image' {
     import * as React from 'react'
   
-    export interface ImgProps extends React.ComponentPropsWithoutRef<'img'> {
+    export interface ImgProps extends Omit<React.ComponentPropsWithoutRef<'img'>, 'src'> {
       src?: string | string[]
       loader?: JSX.Element
       unloader?: JSX.Element


### PR DESCRIPTION
Applied the discussed changes to omit the `src` property from `React.ComponentPropsWithoutRef` type.
Fixes #260 .