### PR TITLE
feat: add cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.4
+
+- Add cache invalidation. So we can invalidate cache on a per image basis.
+
 # 4.0.3
 
 - Update peerDependencies in package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.0.4
 
-- Add cache invalidation. So we can invalidate cache on a per image basis.
+- Add cache invalidation. We can invalidate the cache on a per image basis.
 
 # 4.0.3
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export default function MyComponent() {
 
 - `useSuspense`: boolean. By default, `useImage` will tell React to suspend rendering until an image is downloaded. Suspense can be disabled by setting this to false.
 
-- `invalidateCache`: boolean. `false` by default. `useImage` will cache the image response in a cache object unless the page is reloaded. Invalidate cache by setting this to `true`.
+- `invalidateCache`: boolean. `false` by default. `useImage` will cache the image response in a cache object unless the page is reloaded. Invalidate an image component's cache by setting this to `true`.
 
 **returns:**
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ export default function MyComponent() {
 
 - `useSuspense`: boolean. By default, `useImage` will tell React to suspend rendering until an image is downloaded. Suspense can be disabled by setting this to false.
 
+- `invalidateCache`: boolean. `false` by default. `useImage` will cache the image response in a cache object unless the page is reloaded. Invalidate cache by setting this to `true`.
+
 **returns:**
 
 - `src`: the resolved image address
@@ -111,7 +113,13 @@ const myComponent = () => (
 )
 ```
 
-If an image has previously been attempted unsuccessfully, `react-image` will not retry loading it again until the page is reloaded.
+### Cache:
+
+Image response is stored in a cache object with the `src` as the key. If an image has previously been attempted unsuccessfully, `react-image` will not retry loading it again until the page is reloaded. You can invalidate the cache per image by setting `invalidateCache` to `true`.
+
+```js
+<img src="https://www.example.com/foo.jpg" invalidateCache>
+```
 
 ### Show a "spinner" or other element before the image is loaded:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "React Image is an <img> tag replacement for react, featuring preloader and multiple image fallback support",
   "scripts": {
     "build": "npm run build:types && NODE_ENV=production rollup -c && for i in cjs esm umd; do cp src/*test.js $i; done && rm -rf jsSrc",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -17,7 +17,11 @@ const imgPromise = (decode) => (src) => {
     img.src = src
 
     // mock loading
-    src.endsWith('LOAD') ? img.onload() : img.onerror()
+    if (src.endsWith('CACHE')) {
+      img.onload();
+    } else {
+      src.endsWith('LOAD') ? img.onload() : img.onerror()
+    }
   })
 }
 
@@ -126,4 +130,14 @@ test('onError does nothing if unmounted', async () => {
 
   //unmount()
   setTimeout(() => unmount(), 1)
+})
+
+test('invalidate cache', async () => {
+  // sets the cache
+  const {rerender} = render(<Img src="fooCACHE" imgPromise={imgPromise} />)
+
+  waitFor(() => expect(getByAltText('').src).toEqual(location.href + 'foo'))
+  // invalidates the cache. imgPromise will treat both src as the same cache key
+  rerender(<Img src="bazCACHE" imgPromise={imgPromise} invalidateCache />)
+  waitFor(() => expect(getByAltText('').src).toEqual(location.href + 'bar'))
 })

--- a/src/useImage.tsx
+++ b/src/useImage.tsx
@@ -5,6 +5,7 @@ export type useImageProps = {
   srcList: string | string[]
   imgPromise?: (...args: any[]) => Promise<void>
   useSuspense?: boolean
+  invalidateCache?: boolean
 }
 
 const removeBlankArrayElements = (a) => a.filter((x) => x)
@@ -37,13 +38,14 @@ export default function useImage({
   srcList,
   imgPromise = imagePromiseFactory({decode: true}),
   useSuspense = true,
+  invalidateCache = false,
 }: useImageProps): {src: string | undefined; isLoading: boolean; error: any} {
   const [, setIsLoading] = useState(true)
   const sourceList = removeBlankArrayElements(stringToArray(srcList))
   const sourceKey = sourceList.join('')
 
-  if (!cache[sourceKey]) {
-    // create promise to loop through sources and try to load one
+  if (!cache[sourceKey] || invalidateCache) {
+    // create or reset the promise to loop through sources and try to load one
     cache[sourceKey] = {
       promise: promiseFind(sourceList, imgPromise),
       cache: 'pending',


### PR DESCRIPTION
There is no way to invalidate one particular's image cache unless the whole page is reloaded which will purge entire cache object. I am not sure if this goes against the package's whole point as user can specify multiple fallback image urls. 

My use case is serving lots of images, and very rarely none of the image fallback will work. So it would great to just invalidate 1 image's cache instead of reloading the page. 

First time contributing to OSS, let me know if I've missed anything.