### PR TITLE
Add support for cross origin prop case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.4
+
+- adds support for crossOrigin prop. If both crossorigin and crossOrigin present, uses the one defined last
 # 4.0.3
 
 - Update peerDependencies in package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.0.4
 
 - adds support for crossOrigin prop. If both crossorigin and crossOrigin present, uses the one defined last
+
 # 4.0.3
 
 - Update peerDependencies in package.json

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ const myComponent = () => (
 
 ### Loading images with a CORS policy
 
-When loading images from another domain with a [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes), you may find you need to use the `crossorigin` attribute. For example:
+When loading images from another domain with a [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes), you may find you need to use the `crossOrigin` attribute. For example:
 
 ```js
 const myComponent = () => (
-  <Img src={'https://www.example.com/foo.jpg'} crossorigin="anonymous" />
+  <Img src={'https://www.example.com/foo.jpg'} crossOrigin="anonymous" />
 )
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "React Image is an <img> tag replacement for react, featuring preloader and multiple image fallback support",
   "scripts": {
     "build": "npm run build:types && NODE_ENV=production rollup -c && for i in cjs esm umd; do cp src/*test.js $i; done && rm -rf jsSrc",

--- a/src/Img.tsx
+++ b/src/Img.tsx
@@ -33,8 +33,21 @@ export default function Img({
   useSuspense = false,
   ...imgProps // anything else will be passed to the <img> element
 }: ImgProps): JSX.Element | null {
+  const { crossorigin, crossOrigin } = imgProps ?? {}
+
+  const crossOriginToUse = (() => {
+    if (crossorigin !== undefined && crossOrigin !== undefined) {
+      const imgPropsKeys = Object.keys(imgProps)
+      const crossoriginIndex = imgPropsKeys.findIndex((x) => x === 'crossorigin')
+      const crossOriginIndex = imgPropsKeys.findIndex((x) => x === 'crossOrigin')
+      return crossOriginIndex > crossoriginIndex ? crossOrigin : crossorigin
+    }
+    return crossOrigin ?? crossorigin
+  })()
+
   imgPromise =
-    imgPromise || imagePromiseFactory({decode, crossOrigin: crossorigin})
+    imgPromise || imagePromiseFactory({decode, crossOrigin: crossOriginToUse})
+
   const {src, isLoading} = useImage({
     srcList,
     imgPromise,

--- a/src/Img.tsx
+++ b/src/Img.tsx
@@ -13,8 +13,7 @@ export type ImgProps = Omit<
     src: useImageProps['srcList'] // same types, different name
     loader?: JSX.Element | null
     unloader?: JSX.Element | null
-    decode?: boolean
-    crossorigin?: string
+    decode?: boolean,
     container?: (children: React.ReactNode) => JSX.Element
     loaderContainer?: (children: React.ReactNode) => JSX.Element
     unloaderContainer?: (children: React.ReactNode) => JSX.Element

--- a/src/Img.tsx
+++ b/src/Img.tsx
@@ -30,7 +30,6 @@ export default function Img({
   loaderContainer = passthroughContainer,
   unloaderContainer = passthroughContainer,
   imgPromise,
-  crossorigin,
   useSuspense = false,
   ...imgProps // anything else will be passed to the <img> element
 }: ImgProps): JSX.Element | null {


### PR DESCRIPTION
# Purpose # 
- Resolves  #967: adds support for the crossOrigin prop. If both crossorigin and crossOrigin present, uses the one defined last. 