### PR TITLE
feat: abort downloads on unmount

### DIFF
--- a/dev/app.tsx
+++ b/dev/app.tsx
@@ -164,6 +164,48 @@ const ReuseCache = ({renderId}) => {
   )
 }
 
+const CancelOnUnmount = () => {
+  const [src] = useState(
+    `/delay/2000/https://picsum.photos/200?rand=${Math.random()}`,
+  )
+  const [networkCalls, setNetworkCalls] = useState(-1)
+  const [shouldShow, setShouldShow] = useState(true)
+
+  useEffect(() => {
+    setTimeout(() => {
+      const entires = performance.getEntriesByName(src)
+      setNetworkCalls(entires.length)
+      setShouldShow(false)
+    }, 500)
+  })
+
+  return (
+    <div>
+      <h3>Unmounted component should cancel download</h3>
+      <div>
+        {networkCalls < 0 && <span>❓ test pending</span>}
+        {networkCalls === 0 && <span>✅ test passed</span>}
+        {networkCalls > 0 && <span>❌ test failed.</span>}
+      </div>
+      <div>Network Calls detected: {networkCalls} (expecting 0)</div>
+      <br />
+      <div style={{color: 'grey'}}>
+        To test this manually, check the Network Tab in DevTools to ensure the
+        url
+        <code> {src} </code> is marked as canceled
+      </div>
+      <br />
+      <br />
+
+      {shouldShow ? (
+        <Img style={{width: 100, margin: '10px'}} src={src} />
+      ) : (
+        <></>
+      )}
+    </div>
+  )
+}
+
 function ChangeSrc({renderId}) {
   const getSrc = () => {
     const rand = randSeconds(500, 900)
@@ -209,7 +251,7 @@ function ChangeSrc({renderId}) {
       Src list:
       {src.map((url, index) => {
         return (
-          <div>
+          <div key={Math.random()}>
             {index + 1}. <code>{url}</code>
           </div>
         )
@@ -223,6 +265,7 @@ function ChangeSrc({renderId}) {
       <br />
       <Img
         ref={imgRef}
+        decode={true}
         style={{width: 100}}
         src={src.at(-1) as string}
         loader={<div>Loading...</div>}
@@ -290,7 +333,6 @@ function App() {
             <button onClick={() => setRenderId(Math.random())}>rerender</button>
           </div>
         </div>
-
         <div className="testCases">
           <div className="testCase">
             <h3>Should show</h3>
@@ -365,6 +407,9 @@ function App() {
             <ErrorBoundary>
               <HooksLegacyExample rand={rand4} />
             </ErrorBoundary>
+          </div>
+          <div className="testCase">
+            <CancelOnUnmount key={renderId} />
           </div>
         </div>
       </div>

--- a/dev/sw.js
+++ b/dev/sw.js
@@ -16,7 +16,6 @@ self.addEventListener('fetch', async (event) => {
   const url = new URL(event.request.url)
 
   if (!event.request.url.startsWith(url.origin + '/delay/')) {
-    console.log('not delaying', event.request.url)
     return fetch(event.request)
   }
 

--- a/src/imagePromiseFactory.ts
+++ b/src/imagePromiseFactory.ts
@@ -1,6 +1,6 @@
 // returns a Promisized version of Image() api
 export default ({decode = true, crossOrigin = ''}) =>
-  (src): Promise<void> => {
+  (src, {signal}): Promise<void> => {
     return new Promise((resolve, reject) => {
       const i = new Image()
       if (crossOrigin) i.crossOrigin = crossOrigin
@@ -9,5 +9,9 @@ export default ({decode = true, crossOrigin = ''}) =>
       }
       i.onerror = reject
       i.src = src
+      signal.addEventListener('abort', () => {
+        i.src = ''
+        resolve()
+      })
     })
   }


### PR DESCRIPTION
When the component is unmounted, attempt to cancel the image download. When using native `<img />` tags, the browser does this by default. In order to test if the image is available to be displayed, we use the js `Image()` API and we need to manually tell it to stop downloading.

Fixed https://github.com/mbrevda/react-image/issues/290 by automatically canceling the download on unmount.